### PR TITLE
PE-3193: determine the enum value based off of its constant values instead of casting the type

### DIFF
--- a/src/hooks/useTransactionData/useTransactionData.tsx
+++ b/src/hooks/useTransactionData/useTransactionData.tsx
@@ -1,7 +1,14 @@
 import { useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
-import { AntInteraction, ContractType, RegistryInteraction } from '../../types';
+import {
+  ANT_INTERACTION_TYPES,
+  AntInteraction,
+  CONTRACT_TYPES,
+  ContractType,
+  REGISTRY_INTERACTION_TYPES,
+  RegistryInteraction,
+} from '../../types';
 import { getTransactionPayloadByInteractionType } from '../../utils/searchUtils';
 
 function useTransactionData() {
@@ -12,18 +19,34 @@ function useTransactionData() {
   const [URLAssetId, setURLAssetId] = useState<string>(
     () => searchParams.get('assetId') ?? '',
   );
-  const [URLContractType, setURLContractType] = useState<ContractType>(
-    () =>
-      (searchParams.get('contractType') as ContractType) ??
-      ('' as ContractType),
-  );
+  const [URLContractType, setURLContractType] = useState<ContractType>(() => {
+    const contractType = searchParams.get('contractType') ?? '';
+    const upperCaseContractType = contractType.toUpperCase();
+    if (Object.keys(CONTRACT_TYPES).includes(upperCaseContractType)) {
+      const k = upperCaseContractType as keyof typeof CONTRACT_TYPES;
+      return CONTRACT_TYPES[k];
+    } else {
+      return CONTRACT_TYPES.UNKNOWN;
+    }
+  });
   const [URLInteractionType, setURLInteractionType] = useState<
     AntInteraction | RegistryInteraction
-  >(
-    (searchParams.get('interactionType') as
-      | AntInteraction
-      | RegistryInteraction) ?? ('' as AntInteraction | RegistryInteraction),
-  );
+  >(() => {
+    const interactionType = searchParams.get('interactionType') ?? '';
+    const upperCaseInteractionType = interactionType.toUpperCase();
+    if (Object.keys(ANT_INTERACTION_TYPES).includes(upperCaseInteractionType)) {
+      const k = upperCaseInteractionType as keyof typeof ANT_INTERACTION_TYPES;
+      return ANT_INTERACTION_TYPES[k];
+    } else if (
+      Object.keys(REGISTRY_INTERACTION_TYPES).includes(upperCaseInteractionType)
+    ) {
+      const k =
+        upperCaseInteractionType as keyof typeof REGISTRY_INTERACTION_TYPES;
+      return REGISTRY_INTERACTION_TYPES[k];
+    } else {
+      return ANT_INTERACTION_TYPES.UNKNOWN;
+    }
+  });
 
   useEffect(() => {
     const newURLAssetId = searchParams.get('assetId');

--- a/src/types.ts
+++ b/src/types.ts
@@ -227,6 +227,7 @@ export enum TRANSACTION_TYPES {
 export enum CONTRACT_TYPES {
   REGISTRY = 'ArNS Registry',
   ANT = 'Arweave Name Token',
+  UNKNOWN = 'Unknown',
 }
 
 export enum ASSET_TYPES {
@@ -241,6 +242,7 @@ export enum REGISTRY_INTERACTION_TYPES {
   UPGRADE_TIER = 'Upgrade Tier',
   TRANSFER = 'Transfer IO Tokens',
   BALANCE = 'Balance',
+  UNKNOWN = 'Unknown',
 }
 
 export type TransactionDataBasePayload = {
@@ -310,6 +312,7 @@ export enum ANT_INTERACTION_TYPES {
   TRANSFER = 'Transfer',
   BALANCE = 'Balance',
   CREATE = 'Create Arweave Name Token',
+  UNKNOWN = 'Unknown',
 }
 
 export type ContractType = (typeof CONTRACT_TYPES)[keyof typeof CONTRACT_TYPES];
@@ -376,10 +379,10 @@ export type TransactionDataConfig = { functionName: string; keys: string[] };
 export const TRANSACTION_DATA_KEYS: {
   // specifying interaction types to the correct contract type, to ensure clarity and to prevent crossover of interaction types
   [CONTRACT_TYPES.ANT]: {
-    [K in AntInteraction]: TransactionDataConfig;
+    [K in Exclude<AntInteraction, 'Unknown'>]: TransactionDataConfig;
   };
   [CONTRACT_TYPES.REGISTRY]: {
-    [K in RegistryInteraction]: TransactionDataConfig;
+    [K in Exclude<RegistryInteraction, 'Unknown'>]: TransactionDataConfig;
   };
   /**
    NOTE: benefit of this setup, is that if a new type is added to an enum like ANT_INTERACTION_TYPES, 

--- a/src/utils/searchUtils.ts
+++ b/src/utils/searchUtils.ts
@@ -99,6 +99,18 @@ export function isInteractionCompatible({
   functionName: string;
 }) {
   try {
+    if (contractType === CONTRACT_TYPES.UNKNOWN) {
+      throw new Error(`contract type of ${contractType} is not compatible`);
+    }
+    if (
+      interactionType === ANT_INTERACTION_TYPES.UNKNOWN ||
+      interactionType === REGISTRY_INTERACTION_TYPES.UNKNOWN
+    ) {
+      throw new Error(
+        `interaction type of ${interactionType} is not compatible`,
+      );
+    }
+
     if (
       (contractType === CONTRACT_TYPES.ANT &&
         !isAntInteraction(interactionType)) ||
@@ -147,6 +159,18 @@ export function getTransactionPayloadByInteractionType(
   data: string | string[],
 ) {
   try {
+    if (contractType === CONTRACT_TYPES.UNKNOWN) {
+      throw new Error(`contract type of ${contractType} is not compatible`);
+    }
+    if (
+      interactionType === ANT_INTERACTION_TYPES.UNKNOWN ||
+      interactionType === REGISTRY_INTERACTION_TYPES.UNKNOWN
+    ) {
+      throw new Error(
+        `interaction type of ${interactionType} is not compatible`,
+      );
+    }
+
     const payload: { [x: string]: any } = {};
     const txData = typeof data === 'string' ? [data] : [...data];
 


### PR DESCRIPTION
This is a suggestion to open a discussion about dynamic values being mapped to (constant) enum values.

My main concern here: we were previously casting a string into an enum. And:
1. When utilizing the keyword `as`, we're telling TypeScript that it can trust that the value has a certain type.
2. After compiled, the casts will be removed. E.i. casting a value won't have any effect on the logic.
3. When the enum is evaluated in a switch/case, it doesn't make sense to have the default case if we cover every possible value the enum can have.

So what I'd like from this PR is to treat unknown/unexpected values accordingly by either throwing an error when we parse the dynamic value (which comes from the search parameters) or by having a placeholder value for the unknown case (see the UNKNOWN values I added to the enums).