### PR TITLE
feat(ar-io): use ar-io.dev as default gateway for gql and other queries

### DIFF
--- a/404.html
+++ b/404.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/pdns.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta property="og:title" content="PDNS - ar.io" />
     <meta

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/pdns.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta property="og:title" content="PDNS - ar.io" />
     <meta

--- a/src/services/arweave/SimpleArweaveDataProvider.ts
+++ b/src/services/arweave/SimpleArweaveDataProvider.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import Arweave from 'arweave/node';
 import Ar from 'arweave/node/ar';
 
@@ -6,7 +5,6 @@ import {
   ArweaveDataProvider,
   ArweaveTransactionID,
   TransactionHeaders,
-  TransactionTag,
 } from '../../types';
 import { tagsToObject } from '../../utils';
 import {

--- a/src/services/arweave/WarpDataProvider.ts
+++ b/src/services/arweave/WarpDataProvider.ts
@@ -31,7 +31,7 @@ export class WarpDataProvider
       {
         ...defaultCacheOptions,
       },
-      true,
+      false,
       arweave,
     );
   }

--- a/src/state/contexts/GlobalState.tsx
+++ b/src/state/contexts/GlobalState.tsx
@@ -31,7 +31,7 @@ const initialState: GlobalState = {
     ticker: '',
     approvedANTSourceCodeTxs: [],
   },
-  gateway: 'arweave.net',
+  gateway: 'ar-io.dev',
   walletAddress: undefined,
   wallet: undefined,
 };


### PR DESCRIPTION
We'll move most of the gateway `gql` queries to the `pdns-service` but this will help validate and identify any material issues in the `ar-io.dev` gateway.