### PR TITLE
fix(PE-3587): type tantrum

### DIFF
--- a/src/components/layout/TransactionComplete/TransactionComplete.tsx
+++ b/src/components/layout/TransactionComplete/TransactionComplete.tsx
@@ -2,10 +2,8 @@ import { Link, useNavigate } from 'react-router-dom';
 
 import {
   ArweaveTransactionID,
-  ContractType,
-  PDNTInteraction,
-  RegistryInteraction,
   TransactionData,
+  ValidInteractionType,
 } from '../../../types';
 import { WARP_CONTRACT_BASE_URL } from '../../../utils/constants';
 import eventEmitter from '../../../utils/events';
@@ -15,18 +13,15 @@ import { ArrowUpRight } from '../../icons';
 
 function TransactionComplete({
   transactionId,
-  contractType,
   interactionType,
   transactionData,
 }: {
   transactionId?: ArweaveTransactionID;
-  contractType: ContractType;
-  interactionType: PDNTInteraction | RegistryInteraction;
+  interactionType: ValidInteractionType;
   transactionData: TransactionData;
 }) {
   const navigate = useNavigate();
   const pdntProps = getPDNSMappingByInteractionType({
-    contractType,
     interactionType,
     transactionData,
   });

--- a/src/components/layout/TransactionWorkflow/TransactionWorkflow.tsx
+++ b/src/components/layout/TransactionWorkflow/TransactionWorkflow.tsx
@@ -235,6 +235,13 @@ function TransactionWorkflow({
                 3: { title: 'Complete', status: '' },
               };
             }
+            case PDNT_INTERACTION_TYPES.SET_TTL_SECONDS: {
+              return {
+                1: { title: 'Confirm TTL Seconds', status: 'pending' },
+                2: { title: 'Deploy TTL Seconds Change', status: '' },
+                3: { title: 'Complete', status: '' },
+              };
+            }
             default:
               throw new Error(
                 `Invalid workflow stage (${workflowStage}), workflow stage must be a number between 1 and 4`,
@@ -271,6 +278,7 @@ function TransactionWorkflow({
       switch (contractType) {
         case CONTRACT_TYPES.PDNT: {
           switch (interactionType) {
+            case PDNT_INTERACTION_TYPES.SET_TTL_SECONDS:
             case PDNT_INTERACTION_TYPES.SET_TARGET_ID:
             case PDNT_INTERACTION_TYPES.SET_TICKER:
             case PDNT_INTERACTION_TYPES.SET_NAME: {

--- a/src/components/layout/TransactionWorkflow/TransactionWorkflow.tsx
+++ b/src/components/layout/TransactionWorkflow/TransactionWorkflow.tsx
@@ -6,17 +6,15 @@ import { useTransactionState } from '../../../state/contexts/TransactionState';
 import {
   ArweaveTransactionID,
   BuyRecordPayload,
-  CONTRACT_TYPES,
-  ContractType,
-  PDNTInteraction,
-  PDNT_INTERACTION_TYPES,
-  REGISTRY_INTERACTION_TYPES,
-  RegistryInteraction,
-  TRANSACTION_DATA_KEYS,
+  ExcludedValidInteractionType,
+  INTERACTION_TYPES,
   TransactionData,
+  ValidInteractionType,
 } from '../../../types';
 import {
+  TRANSACTION_DATA_KEYS,
   getPDNSMappingByInteractionType,
+  getWorkflowStepsForInteraction,
   isObjectOfTransactionPayloadType,
 } from '../../../utils';
 import { PDNTCard } from '../../cards';
@@ -32,13 +30,11 @@ export enum TRANSACTION_WORKFLOW_STATUS {
 }
 
 function TransactionWorkflow({
-  contractType,
   interactionType,
   transactionData,
   workflowStage,
 }: {
-  contractType: ContractType;
-  interactionType: PDNTInteraction | RegistryInteraction;
+  interactionType: ExcludedValidInteractionType;
   transactionData: TransactionData;
   workflowStage: TRANSACTION_WORKFLOW_STATUS;
 }) {
@@ -52,24 +48,17 @@ function TransactionWorkflow({
         [x: number]: { title: string; status: string };
       }
     | undefined
-  >(() =>
-    getStepsByTransactionType({
-      contractType,
-      interactionType,
-    }),
-  );
+  >(() => getWorkflowStepsForInteraction(interactionType));
   const [stages, setStages] = useState<
     { [x: string]: WorkflowStage } | undefined
   >(() =>
     getStagesByTransactionType({
-      contractType,
       interactionType,
     }),
   );
 
   useEffect(() => {
     const newStages = getStagesByTransactionType({
-      contractType,
       interactionType,
     });
     if (newStages) setStages(newStages);
@@ -90,10 +79,7 @@ function TransactionWorkflow({
         case 'next':
           switch (workflowStage) {
             case TRANSACTION_WORKFLOW_STATUS.PENDING: {
-              const newSteps = getStepsByTransactionType({
-                contractType,
-                interactionType,
-              });
+              const newSteps = getWorkflowStepsForInteraction(interactionType);
               newSteps['1'].status = 'success';
               newSteps['2'].status = 'pending';
               setSteps(newSteps);
@@ -142,265 +128,124 @@ function TransactionWorkflow({
       console.error(error);
     }
   }
-  function getStepsByTransactionType({
-    contractType,
-    interactionType,
-  }: {
-    contractType: ContractType;
-    interactionType: PDNTInteraction | RegistryInteraction;
-  }): { [x: string]: { title: string; status: string } } {
-    try {
-      switch (contractType) {
-        case CONTRACT_TYPES.REGISTRY:
-          switch (interactionType) {
-            case REGISTRY_INTERACTION_TYPES.BUY_RECORD: {
-              return {
-                1: { title: 'Confirm Registration', status: 'pending' },
-                2: { title: 'Deploy Registration', status: '' },
-                3: { title: 'Complete', status: '' },
-              };
-            }
-            case REGISTRY_INTERACTION_TYPES.EXTEND_LEASE: {
-              return {
-                1: { title: 'Confirm Extension', status: 'pending' },
-                2: { title: 'Deploy Extension', status: '' },
-                3: { title: 'Complete', status: '' },
-              };
-            }
-            case REGISTRY_INTERACTION_TYPES.TRANSFER: {
-              return {
-                1: { title: 'Confirm IO Transfer', status: 'pending' },
-                2: { title: 'Deploy Transfer', status: '' },
-                3: { title: 'Complete', status: '' },
-              };
-            }
-            case REGISTRY_INTERACTION_TYPES.UPGRADE_TIER: {
-              return {
-                1: { title: 'Confirm Tier', status: 'pending' },
-                2: { title: 'Deploy Tier Upgrade', status: '' },
-                3: { title: 'Complete', status: '' },
-              };
-            }
-            default:
-              throw new Error(`Invalid interaction type (${interactionType})`);
-          }
-        case CONTRACT_TYPES.PDNT:
-          switch (interactionType) {
-            case PDNT_INTERACTION_TYPES.REMOVE_RECORD: {
-              return {
-                1: { title: 'Confirm Removal', status: 'pending' },
-                2: { title: 'Deploy Removal', status: '' },
-                3: { title: 'Complete', status: '' },
-              };
-            }
-            case PDNT_INTERACTION_TYPES.SET_CONTROLLER: {
-              return {
-                1: { title: 'Confirm Controller', status: 'pending' },
-                2: { title: 'Deploy Controller', status: '' },
-                3: { title: 'Complete', status: '' },
-              };
-            }
-            case PDNT_INTERACTION_TYPES.SET_NAME: {
-              return {
-                1: { title: 'Confirm PDNT Name', status: 'pending' },
-                2: { title: 'Deploy Name Change', status: '' },
-                3: { title: 'Complete', status: '' },
-              };
-            }
-            case PDNT_INTERACTION_TYPES.SET_RECORD: {
-              return {
-                1: { title: 'Confirm Undername Details', status: 'pending' },
-                2: { title: 'Deploy Undername', status: '' },
-                3: { title: 'Complete', status: '' },
-              };
-            }
-            case PDNT_INTERACTION_TYPES.SET_TICKER: {
-              return {
-                1: { title: 'Confirm Ticker', status: 'pending' },
-                2: { title: 'Deploy Ticker Change', status: '' },
-                3: { title: 'Complete', status: '' },
-              };
-            }
-            case PDNT_INTERACTION_TYPES.TRANSFER: {
-              return {
-                1: { title: 'Confirm Transfer', status: 'pending' },
-                2: { title: 'Deploy Transfer', status: '' },
-                3: { title: 'Complete', status: '' },
-              };
-            }
-            case PDNT_INTERACTION_TYPES.SET_TARGET_ID: {
-              return {
-                1: { title: 'Confirm Target ID', status: 'pending' },
-                2: { title: 'Deploy Target ID Change', status: '' },
-                3: { title: 'Complete', status: '' },
-              };
-            }
-            case PDNT_INTERACTION_TYPES.SET_TTL_SECONDS: {
-              return {
-                1: { title: 'Confirm TTL Seconds', status: 'pending' },
-                2: { title: 'Deploy TTL Seconds Change', status: '' },
-                3: { title: 'Complete', status: '' },
-              };
-            }
-            default:
-              throw new Error(
-                `Invalid workflow stage (${workflowStage}), workflow stage must be a number between 1 and 4`,
-              );
-          }
-        default:
-          throw new Error(
-            `Invalid transaction type: {${contractType}}, Only registry or pdnt types may be provided as a transaction type`,
-          );
-      }
-    } catch (error) {
-      console.log(error);
-      return {};
-    }
-  }
-
   function getStagesByTransactionType({
-    contractType,
     interactionType,
   }: {
-    contractType: ContractType;
-    interactionType: PDNTInteraction | RegistryInteraction;
+    interactionType: ValidInteractionType;
   }): { [x: string]: WorkflowStage } | undefined {
-    try {
-      const pdntProps = getPDNSMappingByInteractionType({
-        contractType,
-        interactionType,
-        transactionData,
-      });
+    const pdntProps = getPDNSMappingByInteractionType({
+      interactionType,
+      transactionData,
+    });
 
-      if (!pdntProps) {
-        throw Error('Unable to get PDNT properties.');
+    if (!pdntProps) {
+      throw Error('Unable to get PDNT properties.');
+    }
+    switch (interactionType) {
+      case INTERACTION_TYPES.SET_TTL_SECONDS:
+      case INTERACTION_TYPES.SET_TARGET_ID:
+      case INTERACTION_TYPES.SET_TICKER:
+      case INTERACTION_TYPES.SET_NAME: {
+        return {
+          pending: {
+            component: <PDNTCard {...pdntProps} />,
+          },
+          confirmed: {
+            component: <DeployTransaction />,
+            showNext: false,
+            showBack: false,
+          },
+          successful: {
+            component: (
+              <TransactionComplete
+                transactionId={deployedTransactionId}
+                interactionType={interactionType}
+                transactionData={transactionData}
+              />
+            ),
+            showNext: false,
+            showBack: false,
+          },
+          failed: {
+            component: (
+              <TransactionComplete
+                transactionId={deployedTransactionId}
+                interactionType={interactionType}
+                transactionData={transactionData}
+              />
+            ),
+            showNext: false,
+            showBack: false,
+          },
+        };
       }
-      switch (contractType) {
-        case CONTRACT_TYPES.PDNT: {
-          switch (interactionType) {
-            case PDNT_INTERACTION_TYPES.SET_TTL_SECONDS:
-            case PDNT_INTERACTION_TYPES.SET_TARGET_ID:
-            case PDNT_INTERACTION_TYPES.SET_TICKER:
-            case PDNT_INTERACTION_TYPES.SET_NAME: {
-              return {
-                pending: {
-                  component: <PDNTCard {...pdntProps} />,
-                },
-                confirmed: {
-                  component: <DeployTransaction />,
-                  showNext: false,
-                  showBack: false,
-                },
-                successful: {
-                  component: (
-                    <TransactionComplete
-                      transactionId={deployedTransactionId}
-                      contractType={contractType}
-                      interactionType={interactionType}
-                      transactionData={transactionData}
-                    />
-                  ),
-                  showNext: false,
-                  showBack: false,
-                },
-                failed: {
-                  component: (
-                    <TransactionComplete
-                      transactionId={deployedTransactionId}
-                      contractType={contractType}
-                      interactionType={interactionType}
-                      transactionData={transactionData}
-                    />
-                  ),
-                  showNext: false,
-                  showBack: false,
-                },
-              };
-            }
-            default:
-              throw new Error('Interaction type is undefined');
-          }
-        }
-
-        case CONTRACT_TYPES.REGISTRY: {
-          switch (interactionType) {
-            case REGISTRY_INTERACTION_TYPES.BUY_RECORD: {
-              if (
-                !isObjectOfTransactionPayloadType<BuyRecordPayload>(
-                  payload,
-                  TRANSACTION_DATA_KEYS[contractType][interactionType].keys,
-                )
-              )
-                throw Error('Payload is not valid.');
-              return {
-                pending: {
-                  component: <PDNTCard {...pdntProps} />,
-                  header: (
-                    <>
-                      <div className="flex flex-row text-large white bold center">
-                        Confirm Name Purchase
-                      </div>
-                    </>
-                  ),
-                },
-                confirmed: {
-                  component: <DeployTransaction />,
-                  showNext: false,
-                  showBack: false,
-                  header: (
-                    <>
-                      <div className="flex flex-row text-large white bold center">
-                        Deploy Name Purchase
-                      </div>
-                    </>
-                  ),
-                },
-                successful: {
-                  component: (
-                    <TransactionComplete
-                      transactionId={deployedTransactionId}
-                      contractType={contractType}
-                      interactionType={interactionType}
-                      transactionData={transactionData}
-                    />
-                  ),
-                  showNext: false,
-                  showBack: false,
-                  header: (
-                    <>
-                      <div className="flex flex-row text-large white bold center">
-                        <span className="text-large white center">
-                          <b>{payload.name}</b>.arweave.net is yours!
-                        </span>
-                      </div>
-                    </>
-                  ),
-                },
-                failed: {
-                  component: (
-                    <TransactionComplete
-                      transactionId={deployedTransactionId}
-                      contractType={contractType}
-                      interactionType={interactionType}
-                      transactionData={transactionData}
-                    />
-                  ),
-                  showNext: false,
-                  showBack: false,
-                },
-              };
-            }
-            // TODO implement other registry interactions
-            default:
-              throw new Error('Interaction type is undefined');
-          }
-        }
-
-        default:
-          throw new Error('Contract type is undefined');
+      case INTERACTION_TYPES.BUY_RECORD: {
+        if (
+          !isObjectOfTransactionPayloadType<BuyRecordPayload>(
+            payload,
+            TRANSACTION_DATA_KEYS[interactionType].keys,
+          )
+        )
+          throw Error('Payload is not valid.');
+        return {
+          pending: {
+            component: <PDNTCard {...pdntProps} />,
+            header: (
+              <>
+                <div className="flex flex-row text-large white bold center">
+                  Confirm Name Purchase
+                </div>
+              </>
+            ),
+          },
+          confirmed: {
+            component: <DeployTransaction />,
+            showNext: false,
+            showBack: false,
+            header: (
+              <>
+                <div className="flex flex-row text-large white bold center">
+                  Deploy Name Purchase
+                </div>
+              </>
+            ),
+          },
+          successful: {
+            component: (
+              <TransactionComplete
+                transactionId={deployedTransactionId}
+                interactionType={interactionType}
+                transactionData={transactionData}
+              />
+            ),
+            showNext: false,
+            showBack: false,
+            header: (
+              <>
+                <div className="flex flex-row text-large white bold center">
+                  <span className="text-large white center">
+                    <b>{payload.name}</b>.arweave.net is yours!
+                  </span>
+                </div>
+              </>
+            ),
+          },
+          failed: {
+            component: (
+              <TransactionComplete
+                transactionId={deployedTransactionId}
+                interactionType={interactionType}
+                transactionData={transactionData}
+              />
+            ),
+            showNext: false,
+            showBack: false,
+          },
+        };
       }
-    } catch (error) {
-      console.error(error);
+      // TODO implement other registry interactions
+      default:
+        throw new Error('Interaction type is undefined');
     }
   }
 

--- a/src/components/modals/CreatePDNTModal/CreatePDNTModal.tsx
+++ b/src/components/modals/CreatePDNTModal/CreatePDNTModal.tsx
@@ -10,10 +10,9 @@ import {
 import { PDNTContract } from '../../../services/arweave/PDNTContract';
 import {
   ArweaveTransactionID,
-  CONTRACT_TYPES,
+  INTERACTION_TYPES,
   ManagePDNTRow,
   PDNTContractJSON,
-  PDNT_INTERACTION_TYPES,
   TRANSACTION_TYPES,
   TransactionData,
   VALIDATION_INPUT_TYPES,
@@ -614,8 +613,7 @@ function CreatePDNTModal() {
                         ? new ArweaveTransactionID(pdntContractId.toString())
                         : undefined
                     }
-                    contractType={CONTRACT_TYPES.PDNT}
-                    interactionType={PDNT_INTERACTION_TYPES.CREATE}
+                    interactionType={INTERACTION_TYPES.CREATE}
                     transactionData={
                       {
                         initialState: pdnt.state,

--- a/src/components/modals/ManagePDNTModal/ManagePDNTModal.tsx
+++ b/src/components/modals/ManagePDNTModal/ManagePDNTModal.tsx
@@ -9,7 +9,6 @@ import { useGlobalState } from '../../../state/contexts/GlobalState';
 import { useTransactionState } from '../../../state/contexts/TransactionState';
 import {
   ArweaveTransactionID,
-  CONTRACT_TYPES,
   ManagePDNTRow,
   PDNSRecordEntry,
   PDNTContractJSON,
@@ -307,12 +306,11 @@ function ManagePDNTModal() {
                             borderColor: 'var(--accent)',
                           }}
                           onClick={() => {
-                            // TODO update when pdnt source code is updated to not overwrite existing info
+                            // TODO: make this more clear, we should be updating only the value that matters and not overwriting anything
                             const payload =
                               row.interactionType ===
                               PDNT_INTERACTION_TYPES.SET_TARGET_ID
                                 ? mapTransactionDataKeyToPayload(
-                                    CONTRACT_TYPES.PDNT,
                                     row.interactionType,
                                     [
                                       '@',
@@ -323,7 +321,6 @@ function ManagePDNTModal() {
                                 : row.interactionType ===
                                   PDNT_INTERACTION_TYPES.SET_TTL_SECONDS
                                 ? mapTransactionDataKeyToPayload(
-                                    CONTRACT_TYPES.PDNT,
                                     row.interactionType,
                                     [
                                       '@',
@@ -335,31 +332,24 @@ function ManagePDNTModal() {
                                     ],
                                   )
                                 : mapTransactionDataKeyToPayload(
-                                    CONTRACT_TYPES.PDNT,
                                     row.interactionType,
                                     modifiedValue!.toString(),
                                   );
 
                             if (payload && row.interactionType && id) {
-                              // eslint-disable-next-line
-                              const { assetId, functionName, ...data } =
-                                payload;
-                              dispatchTransactionState({
-                                type: 'setContractType',
-                                payload: CONTRACT_TYPES.PDNT,
-                              });
+                              const transactionData = {
+                                ...payload,
+                                assetId: id,
+                              };
                               dispatchTransactionState({
                                 type: 'setInteractionType',
                                 payload: row.interactionType,
                               });
                               dispatchTransactionState({
                                 type: 'setTransactionData',
-                                payload: {
-                                  assetId: id,
-                                  functionName,
-                                  ...data,
-                                },
+                                payload: transactionData,
                               });
+
                               navigate(`/transaction`, {
                                 state: `/manage/pdnts/${id}`,
                               });

--- a/src/components/modals/ManagePDNTModal/ManagePDNTModal.tsx
+++ b/src/components/modals/ManagePDNTModal/ManagePDNTModal.tsx
@@ -20,7 +20,7 @@ import {
   getInteractionTypeFromField,
   mapTransactionDataKeyToPayload,
 } from '../../../utils';
-import { STUB_ARWEAVE_TXID } from '../../../utils/constants.js';
+import { STUB_ARWEAVE_TXID } from '../../../utils/constants';
 import eventEmitter from '../../../utils/events';
 import { mapKeyToAttribute } from '../../cards/PDNTCard/PDNTCard';
 import { ArrowLeft, CloseIcon, PencilIcon } from '../../icons';

--- a/src/components/modals/ManagePDNTModal/ManagePDNTModal.tsx
+++ b/src/components/modals/ManagePDNTModal/ManagePDNTModal.tsx
@@ -21,6 +21,7 @@ import {
   getInteractionTypeFromField,
   mapTransactionDataKeyToPayload,
 } from '../../../utils';
+import { STUB_ARWEAVE_TXID } from '../../../utils/constants';
 import eventEmitter from '../../../utils/events';
 import { mapKeyToAttribute } from '../../cards/PDNTCard/PDNTCard';
 import { ArrowLeft, CloseIcon, PencilIcon } from '../../icons';
@@ -317,6 +318,20 @@ function ManagePDNTModal() {
                                       '@',
                                       modifiedValue!.toString(),
                                       pdntState!.records['@'].ttlSeconds,
+                                    ],
+                                  )
+                                : row.interactionType ===
+                                  PDNT_INTERACTION_TYPES.SET_TTL_SECONDS
+                                ? mapTransactionDataKeyToPayload(
+                                    CONTRACT_TYPES.PDNT,
+                                    row.interactionType,
+                                    [
+                                      '@',
+                                      pdntState!.records['@'].transactionId
+                                        .length
+                                        ? pdntState!.records['@'].transactionId
+                                        : STUB_ARWEAVE_TXID,
+                                      modifiedValue!,
                                     ],
                                   )
                                 : mapTransactionDataKeyToPayload(

--- a/src/components/pages/Home/Home.tsx
+++ b/src/components/pages/Home/Home.tsx
@@ -8,8 +8,7 @@ import { useTransactionState } from '../../../state/contexts/TransactionState';
 import {
   ArweaveTransactionID,
   BuyRecordPayload,
-  CONTRACT_TYPES,
-  REGISTRY_INTERACTION_TYPES,
+  INTERACTION_TYPES,
 } from '../../../types';
 import {
   FEATURED_DOMAINS,
@@ -105,12 +104,8 @@ function Home() {
                   },
                 });
                 dispatchTransactionState({
-                  type: 'setContractType',
-                  payload: CONTRACT_TYPES.REGISTRY,
-                });
-                dispatchTransactionState({
                   type: 'setInteractionType',
-                  payload: REGISTRY_INTERACTION_TYPES.BUY_RECORD,
+                  payload: INTERACTION_TYPES.BUY_RECORD,
                 });
                 // navigate to the transaction page, which will load the updated state of the transaction context
                 navigate('/transaction', {

--- a/src/components/pages/Transaction/Transaction.tsx
+++ b/src/components/pages/Transaction/Transaction.tsx
@@ -8,7 +8,7 @@ import TransactionWorkflow, {
 } from '../../layout/TransactionWorkflow/TransactionWorkflow';
 
 function Transaction() {
-  const { transactionData, contractType, interactionType, workflowStage } =
+  const { transactionData, interactionType, workflowStage } =
     useTransactionData();
   const from = useLocation().state;
   const [, dispatchTransactionState] = useTransactionState();
@@ -29,7 +29,6 @@ function Transaction() {
     <>
       <div className="page">
         <TransactionWorkflow
-          contractType={contractType}
           interactionType={interactionType}
           transactionData={transactionData}
           workflowStage={workflowStage}

--- a/src/hooks/useTransactionData/useTransactionData.tsx
+++ b/src/hooks/useTransactionData/useTransactionData.tsx
@@ -13,7 +13,7 @@ export function useTransactionData() {
   const [, setSearchParams] = useSearchParams();
   const from = useLocation().state;
 
-  const [{ transactionData, contractType, interactionType, workflowStage }] =
+  const [{ transactionData, interactionType, workflowStage }] =
     useTransactionState();
 
   /**
@@ -31,17 +31,15 @@ export function useTransactionData() {
     const updatedSearchParams = createSearchParams({
       // TODO: sanitize these values
       ...(transactionData as any),
-      contractType,
       interactionType,
       workflowStage,
     });
 
     setSearchParams(updatedSearchParams);
-  }, [transactionData, contractType, interactionType, workflowStage]);
+  }, [transactionData, interactionType, workflowStage]);
 
   return {
     transactionData,
-    contractType,
     interactionType,
     workflowStage,
   };

--- a/src/state/contexts/TransactionState.tsx
+++ b/src/state/contexts/TransactionState.tsx
@@ -3,11 +3,8 @@ import { Dispatch, createContext, useContext, useReducer } from 'react';
 import { TRANSACTION_WORKFLOW_STATUS } from '../../components/layout/TransactionWorkflow/TransactionWorkflow';
 import {
   ArweaveTransactionID,
-  CONTRACT_TYPES,
-  ContractType,
-  PDNTInteraction,
-  REGISTRY_INTERACTION_TYPES,
-  RegistryInteraction,
+  ExcludedValidInteractionType,
+  INTERACTION_TYPES,
   TransactionData,
 } from '../../types';
 import { TransactionAction } from '../reducers/TransactionReducer';
@@ -15,8 +12,7 @@ import { TransactionAction } from '../reducers/TransactionReducer';
 export type TransactionState = {
   deployedTransactionId?: ArweaveTransactionID;
   transactionData: TransactionData | undefined; // data that will be used to perform the transaction.
-  contractType: ContractType;
-  interactionType: PDNTInteraction | RegistryInteraction;
+  interactionType: ExcludedValidInteractionType;
   workflowStage: TRANSACTION_WORKFLOW_STATUS;
 };
 
@@ -27,8 +23,7 @@ export type TransactionStateProviderProps = {
 
 export const initialTransactionState: TransactionState = {
   transactionData: undefined,
-  contractType: CONTRACT_TYPES.REGISTRY,
-  interactionType: REGISTRY_INTERACTION_TYPES.BUY_RECORD,
+  interactionType: INTERACTION_TYPES.BUY_RECORD,
   workflowStage: TRANSACTION_WORKFLOW_STATUS.PENDING, // confirm deploy complete,
 };
 

--- a/src/state/reducers/TransactionReducer.tsx
+++ b/src/state/reducers/TransactionReducer.tsx
@@ -1,9 +1,7 @@
 import { TRANSACTION_WORKFLOW_STATUS } from '../../components/layout/TransactionWorkflow/TransactionWorkflow';
 import {
   ArweaveTransactionID,
-  ContractType,
-  PDNTInteraction,
-  RegistryInteraction,
+  ExcludedValidInteractionType,
   TransactionData,
 } from '../../types';
 import {
@@ -18,10 +16,9 @@ export type TransactionAction =
     }
   | { type: 'setTransactionData'; payload: TransactionData }
   | { type: 'setDeployedTransactionId'; payload: ArweaveTransactionID }
-  | { type: 'setContractType'; payload: ContractType }
   | {
       type: 'setInteractionType';
-      payload: PDNTInteraction | RegistryInteraction;
+      payload: ExcludedValidInteractionType;
     }
   | { type: 'reset' };
 
@@ -46,12 +43,6 @@ export const transactionReducer = (
       return {
         ...state,
         deployedTransactionId: action.payload,
-      };
-    }
-    case 'setContractType': {
-      return {
-        ...state,
-        contractType: action.payload,
       };
     }
     case 'setInteractionType': {

--- a/src/types.ts
+++ b/src/types.ts
@@ -240,13 +240,74 @@ export enum ASSET_TYPES {
   UNDERNAME = 'Undername',
   COIN = 'coin',
 }
-export enum REGISTRY_INTERACTION_TYPES {
-  BUY_RECORD = 'Buy PDNS Name', //permabuy
+export enum INTERACTION_TYPES {
+  // Registry interaction types
+  BUY_RECORD = 'Buy PDNS Name',
   EXTEND_LEASE = 'Extend Lease',
   UPGRADE_TIER = 'Upgrade Tier',
-  TRANSFER = 'Transfer IO Tokens',
+
+  // ANT interaction types
+  SET_CONTROLLER = 'Edit Controller',
+  SET_TICKER = 'Edit Ticker',
+  SET_NAME = 'Edit Name',
+  SET_TTL_SECONDS = 'Edit TTL Seconds',
+  SET_TARGET_ID = 'Edit Target ID',
+  SET_RECORD = 'Edit Record',
+  REMOVE_RECORD = 'Delete Record',
+  CREATE = 'Create Permaweb Name Token',
+
+  // Common interaction types
+  TRANSFER = 'Transfer',
   BALANCE = 'Balance',
+  UNKNOWN = 'Unknown',
 }
+
+const commonInteractionTypeNames = [
+  INTERACTION_TYPES.TRANSFER,
+  INTERACTION_TYPES.BALANCE,
+] as const;
+const unknownInteractionType = INTERACTION_TYPES.UNKNOWN as const;
+export const pdntInteractionTypes = [
+  ...commonInteractionTypeNames,
+  INTERACTION_TYPES.SET_CONTROLLER,
+  INTERACTION_TYPES.SET_TICKER,
+  INTERACTION_TYPES.SET_NAME,
+  INTERACTION_TYPES.SET_TTL_SECONDS,
+  INTERACTION_TYPES.SET_TARGET_ID,
+  INTERACTION_TYPES.SET_RECORD,
+  INTERACTION_TYPES.REMOVE_RECORD,
+  INTERACTION_TYPES.CREATE,
+] as const;
+export const registryInteractionTypes = [
+  ...commonInteractionTypeNames,
+  INTERACTION_TYPES.BUY_RECORD,
+  INTERACTION_TYPES.EXTEND_LEASE,
+  INTERACTION_TYPES.UPGRADE_TIER,
+] as const;
+
+export const interactionTypeNames = [
+  ...pdntInteractionTypes,
+  ...registryInteractionTypes,
+] as const;
+export const contractTypeNames = [
+  CONTRACT_TYPES.REGISTRY,
+  CONTRACT_TYPES.PDNT,
+] as const;
+export type ContractTypes = (typeof contractTypeNames)[number];
+export type InteractionTypes = (typeof interactionTypeNames)[number];
+export type PDNTInteractionType = (typeof pdntInteractionTypes)[number];
+export type RegistryInteractionType = (typeof registryInteractionTypes)[number];
+export type UnknownInteractionTypeName = typeof unknownInteractionType;
+export type ValidInteractionType =
+  | PDNTInteractionType
+  | RegistryInteractionType;
+export type InteractionTypeName =
+  | ValidInteractionType
+  | UnknownInteractionTypeName;
+export type ExcludedValidInteractionType = Exclude<
+  ValidInteractionType,
+  INTERACTION_TYPES.BALANCE | INTERACTION_TYPES.CREATE
+>;
 
 export type TransactionDataBasePayload = {
   assetId: string;
@@ -325,13 +386,6 @@ export enum PDNT_INTERACTION_TYPES {
   CREATE = 'Create Arweave Name Token',
 }
 
-export type ContractType = (typeof CONTRACT_TYPES)[keyof typeof CONTRACT_TYPES];
-
-export type PDNTInteraction =
-  (typeof PDNT_INTERACTION_TYPES)[keyof typeof PDNT_INTERACTION_TYPES];
-export type RegistryInteraction =
-  (typeof REGISTRY_INTERACTION_TYPES)[keyof typeof REGISTRY_INTERACTION_TYPES];
-
 export const ALL_TRANSACTION_DATA_KEYS = [
   'assetId',
   'functionName',
@@ -368,85 +422,6 @@ export type TransactionData = TransactionDataBasePayload &
   TransactionDataPayload;
 
 export type TransactionDataConfig = { functionName: string; keys: string[] };
-
-export const TRANSACTION_DATA_KEYS: {
-  // specifying interaction types to the correct contract type, to ensure clarity and to prevent crossover of interaction types
-  [CONTRACT_TYPES.PDNT]: {
-    [K in PDNTInteraction]: TransactionDataConfig;
-  };
-  [CONTRACT_TYPES.REGISTRY]: {
-    [K in RegistryInteraction]: TransactionDataConfig;
-  };
-  /**
-   NOTE: benefit of this setup, is that if a new type is added to an enum like PDNT_INTERACTION_TYPES, 
-   then an error will occur here, since every key of the type is required to be defined here.
-   */
-} = {
-  [CONTRACT_TYPES.REGISTRY]: {
-    [REGISTRY_INTERACTION_TYPES.BUY_RECORD]: {
-      functionName: 'buyRecord',
-      keys: ['name', 'contractTxId', 'years', 'tierNumber'],
-    },
-    [REGISTRY_INTERACTION_TYPES.EXTEND_LEASE]: {
-      functionName: 'extendLease',
-      keys: ['name', 'years'],
-    },
-    [REGISTRY_INTERACTION_TYPES.UPGRADE_TIER]: {
-      functionName: 'upgradeTier',
-      keys: ['name', 'tierNumber'],
-    },
-    [REGISTRY_INTERACTION_TYPES.TRANSFER]: {
-      functionName: 'transfer',
-      keys: ['target', 'qty'],
-    }, // transfer io tokens
-    [REGISTRY_INTERACTION_TYPES.BALANCE]: {
-      functionName: 'getBalance',
-      keys: ['target'],
-    },
-  },
-  [CONTRACT_TYPES.PDNT]: {
-    [PDNT_INTERACTION_TYPES.SET_TTL_SECONDS]: {
-      functionName: 'setRecord',
-      keys: ['subDomain', 'transactionId', 'ttlSeconds'],
-    },
-    [PDNT_INTERACTION_TYPES.SET_TARGET_ID]: {
-      functionName: 'setRecord',
-      keys: ['subDomain', 'transactionId', 'ttlSeconds'],
-    },
-    [PDNT_INTERACTION_TYPES.SET_TICKER]: {
-      functionName: 'setTicker',
-      keys: ['ticker'],
-    },
-    [PDNT_INTERACTION_TYPES.SET_CONTROLLER]: {
-      functionName: 'setController',
-      keys: ['target'],
-    },
-    [PDNT_INTERACTION_TYPES.SET_NAME]: {
-      functionName: 'setName',
-      keys: ['name'],
-    },
-    [PDNT_INTERACTION_TYPES.SET_RECORD]: {
-      functionName: 'setRecord',
-      keys: ['subDomain', 'transactionId', 'ttlSeconds'],
-    },
-    [PDNT_INTERACTION_TYPES.REMOVE_RECORD]: {
-      functionName: 'removeRecord',
-      keys: ['subDomain'],
-    },
-    [PDNT_INTERACTION_TYPES.TRANSFER]: {
-      functionName: 'transfer',
-      keys: ['target'],
-    },
-    [PDNT_INTERACTION_TYPES.BALANCE]: {
-      functionName: 'balance',
-      keys: ['target'],
-    },
-    [PDNT_INTERACTION_TYPES.CREATE]: {
-      functionName: '',
-      keys: ['srcCodeTransactionId', 'initialState'],
-    },
-  },
-};
 
 export class ArweaveTransactionID implements Equatable<ArweaveTransactionID> {
   constructor(private readonly transactionId: string) {
@@ -505,7 +480,7 @@ export type ManagePDNTRow = {
   editable: boolean;
   action: any;
   key: number;
-  interactionType?: PDNTInteraction | RegistryInteraction;
+  interactionType?: ValidInteractionType;
 };
 
 export enum VALIDATION_INPUT_TYPES {

--- a/src/types.ts
+++ b/src/types.ts
@@ -379,7 +379,7 @@ export enum PDNT_INTERACTION_TYPES {
   SET_NAME = 'Edit Name',
   SET_RECORD = 'Edit Record',
   SET_TARGET_ID = 'Set Target ID',
-  SET_TTL_SECONDS = ' Set TTL Seconds',
+  SET_TTL_SECONDS = 'Set TTL Seconds',
   REMOVE_RECORD = 'Delete Record',
   TRANSFER = 'Transfer',
   BALANCE = 'Balance',

--- a/src/types.ts
+++ b/src/types.ts
@@ -318,6 +318,7 @@ export enum PDNT_INTERACTION_TYPES {
   SET_NAME = 'Edit Name',
   SET_RECORD = 'Edit Record',
   SET_TARGET_ID = 'Set Target ID',
+  SET_TTL_SECONDS = ' Set TTL Seconds',
   REMOVE_RECORD = 'Delete Record',
   TRANSFER = 'Transfer',
   BALANCE = 'Balance',
@@ -404,6 +405,10 @@ export const TRANSACTION_DATA_KEYS: {
     },
   },
   [CONTRACT_TYPES.PDNT]: {
+    [PDNT_INTERACTION_TYPES.SET_TTL_SECONDS]: {
+      functionName: 'setRecord',
+      keys: ['subDomain', 'transactionId', 'ttlSeconds'],
+    },
     [PDNT_INTERACTION_TYPES.SET_TARGET_ID]: {
       functionName: 'setRecord',
       keys: ['subDomain', 'transactionId', 'ttlSeconds'],

--- a/src/utils/transactionUtils/transactionUtils.ts
+++ b/src/utils/transactionUtils/transactionUtils.ts
@@ -3,19 +3,18 @@ import {
   ArweaveTransactionID,
   BuyRecordPayload,
   CONTRACT_TYPES,
-  ContractType,
+  ContractTypes,
   CreatePDNTPayload,
+  ExcludedValidInteractionType,
+  INTERACTION_TYPES,
   PDNSMapping,
-  PDNTInteraction,
-  PDNT_INTERACTION_TYPES,
-  REGISTRY_INTERACTION_TYPES,
-  RegistryInteraction,
   SetNamePayload,
   SetRecordPayload,
   SetTickerPayload,
-  TRANSACTION_DATA_KEYS,
   TransactionData,
+  TransactionDataConfig,
   TransactionDataPayload,
+  ValidInteractionType,
 } from '../../types';
 import { PDNS_TX_ID_REGEX } from '../constants';
 
@@ -29,15 +28,7 @@ export function isArweaveTransactionID(id: string) {
   return true;
 }
 
-export function isPDNTInteraction(x: any): x is PDNTInteraction {
-  return Object.values(PDNT_INTERACTION_TYPES).includes(x);
-}
-
-export function isRegistryInteraction(x: any): x is RegistryInteraction {
-  return Object.values(REGISTRY_INTERACTION_TYPES).includes(x);
-}
-
-export function isContractType(x: any): x is ContractType {
+export function isContractType(x: any): x is ContractTypes {
   return Object.values(CONTRACT_TYPES).includes(x);
 }
 
@@ -50,274 +41,335 @@ export function isObjectOfTransactionPayloadType<
   return requiredKeys.every((k) => Object.keys(x).includes(k));
 }
 
-export function isInteractionCompatible({
-  contractType,
-  interactionType,
-  functionName,
-}: {
-  contractType: ContractType;
-  interactionType: PDNTInteraction | RegistryInteraction;
-  functionName: string;
-}) {
-  try {
-    if (
-      (contractType === CONTRACT_TYPES.PDNT &&
-        !isPDNTInteraction(interactionType)) ||
-      (contractType === CONTRACT_TYPES.REGISTRY &&
-        !isRegistryInteraction(interactionType))
-    ) {
-      throw new Error(
-        `contract type of ${contractType} and interaction type of ${interactionType} are not compatible`,
-      );
+export const WorkflowStepsForInteractions: Record<
+  ExcludedValidInteractionType,
+  Record<
+    number,
+    {
+      title: string;
+      status: string;
     }
-    if (
-      contractType === CONTRACT_TYPES.PDNT &&
-      isPDNTInteraction(interactionType)
-    ) {
-      if (
-        TRANSACTION_DATA_KEYS[contractType][interactionType].functionName !==
-        functionName
-      ) {
-        throw new Error(
-          `function name of ${functionName} is not compatible with contract type ${contractType} and interaction type ${interactionType}`,
-        );
-      }
-    }
-    if (
-      contractType === CONTRACT_TYPES.REGISTRY &&
-      isRegistryInteraction(interactionType)
-    ) {
-      if (
-        TRANSACTION_DATA_KEYS[contractType][interactionType].functionName !==
-        functionName
-      ) {
-        throw new Error(
-          `function name of ${functionName} is not compatible with contract type ${contractType} and interaction type ${interactionType}`,
-        );
-      }
-    }
-    return true;
-  } catch (error) {
-    return false;
-  }
-}
+  >
+> = {
+  [INTERACTION_TYPES.BUY_RECORD]: {
+    1: { title: 'Confirm Registration', status: 'pending' },
+    2: { title: 'Deploy Registration', status: '' },
+    3: { title: 'Complete', status: '' },
+  },
+  [INTERACTION_TYPES.EXTEND_LEASE]: {
+    1: { title: 'Confirm Extension', status: 'pending' },
+    2: { title: 'Deploy Extension', status: '' },
+    3: { title: 'Complete', status: '' },
+  },
+  [INTERACTION_TYPES.UPGRADE_TIER]: {
+    1: { title: 'Confirm Tier', status: 'pending' },
+    2: { title: 'Deploy Tier Upgrade', status: '' },
+    3: { title: 'Complete', status: '' },
+  },
+  [INTERACTION_TYPES.REMOVE_RECORD]: {
+    1: { title: 'Confirm Removal', status: 'pending' },
+    2: { title: 'Deploy Removal', status: '' },
+    3: { title: 'Complete', status: '' },
+  },
+  [INTERACTION_TYPES.SET_CONTROLLER]: {
+    1: { title: 'Confirm Controller', status: 'pending' },
+    2: { title: 'Deploy Controller', status: '' },
+    3: { title: 'Complete', status: '' },
+  },
+  [INTERACTION_TYPES.SET_NAME]: {
+    1: { title: 'Confirm PDNT Name', status: 'pending' },
+    2: { title: 'Deploy Name Change', status: '' },
+    3: { title: 'Complete', status: '' },
+  },
+  [INTERACTION_TYPES.SET_RECORD]: {
+    1: { title: 'Confirm Undername Details', status: 'pending' },
+    2: { title: 'Deploy Undername', status: '' },
+    3: { title: 'Complete', status: '' },
+  },
+  [INTERACTION_TYPES.SET_TICKER]: {
+    1: { title: 'Confirm Ticker', status: 'pending' },
+    2: { title: 'Deploy Ticker Change', status: '' },
+    3: { title: 'Complete', status: '' },
+  },
+  [INTERACTION_TYPES.TRANSFER]: {
+    1: { title: 'Confirm Transfer', status: 'pending' },
+    2: { title: 'Deploy Transfer', status: '' },
+    3: { title: 'Complete', status: '' },
+  },
+  [INTERACTION_TYPES.SET_TARGET_ID]: {
+    1: { title: 'Confirm Target ID', status: 'pending' },
+    2: { title: 'Deploy Target ID Change', status: '' },
+    3: { title: 'Complete', status: '' },
+  },
+  [INTERACTION_TYPES.SET_TTL_SECONDS]: {
+    1: { title: 'Confirm TTL Seconds', status: 'pending' },
+    2: { title: 'Deploy TTL Seconds Change', status: '' },
+    3: { title: 'Complete', status: '' },
+  },
+};
+
+export const TRANSACTION_DATA_KEYS: Record<
+  ValidInteractionType,
+  TransactionDataConfig
+> = {
+  [INTERACTION_TYPES.BUY_RECORD]: {
+    functionName: 'buyRecord',
+    keys: ['name', 'contractTxId', 'years', 'tierNumber'],
+  },
+  [INTERACTION_TYPES.EXTEND_LEASE]: {
+    functionName: 'extendLease',
+    keys: ['name', 'years'],
+  },
+  [INTERACTION_TYPES.UPGRADE_TIER]: {
+    functionName: 'upgradeTier',
+    keys: ['name', 'tierNumber'],
+  },
+  [INTERACTION_TYPES.TRANSFER]: {
+    functionName: 'transfer',
+    keys: ['target', 'qty'],
+  }, // transfer io tokens
+  [INTERACTION_TYPES.BALANCE]: {
+    functionName: 'getBalance',
+    keys: ['target'],
+  },
+  [INTERACTION_TYPES.SET_TTL_SECONDS]: {
+    functionName: 'setRecord',
+    keys: ['subDomain', 'transactionId', 'ttlSeconds'],
+  },
+  [INTERACTION_TYPES.SET_TARGET_ID]: {
+    functionName: 'setRecord',
+    keys: ['subDomain', 'transactionId', 'ttlSeconds'],
+  },
+  [INTERACTION_TYPES.SET_TICKER]: {
+    functionName: 'setTicker',
+    keys: ['ticker'],
+  },
+  [INTERACTION_TYPES.SET_CONTROLLER]: {
+    functionName: 'setController',
+    keys: ['target'],
+  },
+  [INTERACTION_TYPES.SET_NAME]: {
+    functionName: 'setName',
+    keys: ['name'],
+  },
+  [INTERACTION_TYPES.SET_RECORD]: {
+    functionName: 'setRecord',
+    keys: ['subDomain', 'transactionId', 'ttlSeconds'],
+  },
+  [INTERACTION_TYPES.REMOVE_RECORD]: {
+    functionName: 'removeRecord',
+    keys: ['subDomain'],
+  },
+  [INTERACTION_TYPES.CREATE]: {
+    functionName: '',
+    keys: ['srcCodeTransactionId', 'initialState'],
+  },
+};
+
+export const getWorkflowStepsForInteraction = (
+  interaction: ExcludedValidInteractionType,
+): {
+  [x: number]: {
+    title: string;
+    status: string;
+  };
+} => {
+  return WorkflowStepsForInteractions[interaction];
+};
 
 export function getPDNSMappingByInteractionType(
   // can be used to generate PDNTCard props: <PDNTCard {...props = getPDNSMappingByInteractionType()} />
   {
-    contractType,
     interactionType,
     transactionData,
   }: {
-    contractType: ContractType;
-    interactionType: PDNTInteraction | RegistryInteraction;
+    interactionType: ValidInteractionType;
     transactionData: TransactionData;
   },
 ): PDNSMapping | undefined {
-  switch (contractType) {
-    case CONTRACT_TYPES.REGISTRY:
-      {
-        switch (interactionType) {
-          case REGISTRY_INTERACTION_TYPES.BUY_RECORD: {
-            if (
-              !isObjectOfTransactionPayloadType<BuyRecordPayload>(
-                transactionData,
-                TRANSACTION_DATA_KEYS[CONTRACT_TYPES.REGISTRY][
-                  REGISTRY_INTERACTION_TYPES.BUY_RECORD
-                ].keys,
-              )
-            ) {
-              throw new Error(
-                'transaction data not of correct payload type <BuyRecordPayload>',
-              );
-            }
-            return {
-              domain: transactionData.name,
-              id: new ArweaveTransactionID(transactionData.contractTxId),
-              overrides: {
-                tier: transactionData.tierNumber,
-                maxSubdomains: 100, // TODO get subdomain count from contract
-                leaseDuration: transactionData.years,
-              },
-            };
-          }
-        }
+  switch (interactionType) {
+    case INTERACTION_TYPES.BUY_RECORD: {
+      if (
+        !isObjectOfTransactionPayloadType<BuyRecordPayload>(
+          transactionData,
+          TRANSACTION_DATA_KEYS[INTERACTION_TYPES.BUY_RECORD].keys,
+        )
+      ) {
+        throw new Error(
+          'transaction data not of correct payload type <BuyRecordPayload>',
+        );
       }
-      break;
-    case CONTRACT_TYPES.PDNT: {
-      switch (interactionType) {
-        case PDNT_INTERACTION_TYPES.CREATE: {
-          if (
-            !isObjectOfTransactionPayloadType<CreatePDNTPayload>(
-              transactionData,
-              TRANSACTION_DATA_KEYS[CONTRACT_TYPES.PDNT][
-                PDNT_INTERACTION_TYPES.CREATE
-              ].keys,
-            )
-          ) {
-            throw new Error(
-              'transaction data not of correct payload type <CreatePDNTPayload>',
-            );
-          }
-          const pdnt = new PDNTContract(transactionData.initialState);
-          return {
-            domain: '',
-            showTier: false,
-            compact: false,
-            state: pdnt.state,
-            overrides: {
-              targetId: pdnt.getRecord('@').transactionId,
-              ttlSeconds: pdnt.getRecord('@').ttlSeconds,
-            },
-            disabledKeys: [
-              'tier',
-              'evolve',
-              'maxSubdomains',
-              'id',
-              'domain',
-              'leaseDuration',
-            ],
-          };
-        }
-        case PDNT_INTERACTION_TYPES.SET_NAME: {
-          if (
-            !isObjectOfTransactionPayloadType<SetNamePayload>(
-              transactionData,
-              TRANSACTION_DATA_KEYS[CONTRACT_TYPES.PDNT][
-                PDNT_INTERACTION_TYPES.SET_NAME
-              ].keys,
-            )
-          ) {
-            throw new Error(
-              'transaction data not of correct payload type <SetNamePayload>',
-            );
-          }
-          return {
-            domain: '',
-            showTier: false,
-            compact: false,
-            id: new ArweaveTransactionID(transactionData.assetId),
-            overrides: {
-              nickname: transactionData.name,
-            },
-            disabledKeys: [
-              'evolve',
-              'maxSubdomains',
-              'domain',
-              'leaseDuration',
-              'ttlSeconds',
-            ],
-          };
-        }
-        case PDNT_INTERACTION_TYPES.SET_TICKER: {
-          if (
-            !isObjectOfTransactionPayloadType<SetTickerPayload>(
-              transactionData,
-              TRANSACTION_DATA_KEYS[CONTRACT_TYPES.PDNT][
-                PDNT_INTERACTION_TYPES.SET_TICKER
-              ].keys,
-            )
-          ) {
-            throw new Error(
-              `transaction data not of correct payload type <SetTickerPayload> keys: ${Object.keys(
-                transactionData,
-              )}`,
-            );
-          }
-          return {
-            domain: '',
-            showTier: false,
-            compact: false,
-            id: new ArweaveTransactionID(transactionData.assetId),
-            overrides: {
-              ticker: transactionData.ticker,
-            },
-            disabledKeys: [
-              'evolve',
-              'maxSubdomains',
-              'domain',
-              'leaseDuration',
-              'ttlSeconds',
-            ],
-          };
-        }
-        case PDNT_INTERACTION_TYPES.SET_TARGET_ID: {
-          if (
-            !isObjectOfTransactionPayloadType<SetRecordPayload>(
-              transactionData,
-              TRANSACTION_DATA_KEYS[CONTRACT_TYPES.PDNT][
-                PDNT_INTERACTION_TYPES.SET_TARGET_ID
-              ].keys,
-            )
-          ) {
-            throw new Error(
-              `transaction data not of correct payload type <SetRecordPayload> keys: ${Object.keys(
-                transactionData,
-              )}`,
-            );
-          }
-          return {
-            domain: '',
-            showTier: false,
-            compact: false,
-            id: new ArweaveTransactionID(transactionData.assetId),
-            overrides: {
-              targetId: transactionData.transactionId,
-            },
-            disabledKeys: [
-              'evolve',
-              'maxSubdomains',
-              'domain',
-              'leaseDuration',
-              'ttlSeconds',
-              'tier',
-            ],
-          };
-        }
-        case PDNT_INTERACTION_TYPES.SET_TTL_SECONDS: {
-          if (
-            !isObjectOfTransactionPayloadType<SetRecordPayload>(
-              transactionData,
-              TRANSACTION_DATA_KEYS[CONTRACT_TYPES.PDNT][
-                PDNT_INTERACTION_TYPES.SET_TTL_SECONDS
-              ].keys,
-            )
-          ) {
-            throw new Error(
-              `transaction data not of correct payload type <SetRecordPayload> keys: ${Object.keys(
-                transactionData,
-              )}`,
-            );
-          }
-          return {
-            domain: '',
-            showTier: false,
-            compact: false,
-            id: new ArweaveTransactionID(transactionData.assetId),
-            overrides: {
-              ttlSeconds: transactionData.ttlSeconds,
-            },
-            disabledKeys: [
-              'evolve',
-              'maxSubdomains',
-              'domain',
-              'leaseDuration',
-              'tier',
-            ],
-          };
-        }
+      return {
+        domain: transactionData.name,
+        id: new ArweaveTransactionID(transactionData.contractTxId),
+        overrides: {
+          tier: transactionData.tierNumber,
+          maxSubdomains: 100, // TODO get subdomain count from contract
+          leaseDuration: transactionData.years,
+        },
+      };
+    }
+
+    case INTERACTION_TYPES.CREATE: {
+      if (
+        !isObjectOfTransactionPayloadType<CreatePDNTPayload>(
+          transactionData,
+          TRANSACTION_DATA_KEYS[INTERACTION_TYPES.CREATE].keys,
+        )
+      ) {
+        throw new Error(
+          'transaction data not of correct payload type <CreatePDNTPayload>',
+        );
       }
+      const pdnt = new PDNTContract(transactionData.initialState);
+      return {
+        domain: '',
+        showTier: false,
+        compact: false,
+        state: pdnt.state,
+        overrides: {
+          targetId: pdnt.getRecord('@').transactionId,
+          ttlSeconds: pdnt.getRecord('@').ttlSeconds,
+        },
+        disabledKeys: [
+          'tier',
+          'evolve',
+          'maxSubdomains',
+          'id',
+          'domain',
+          'leaseDuration',
+        ],
+      };
+    }
+    case INTERACTION_TYPES.SET_NAME: {
+      if (
+        !isObjectOfTransactionPayloadType<SetNamePayload>(
+          transactionData,
+          TRANSACTION_DATA_KEYS[INTERACTION_TYPES.SET_NAME].keys,
+        )
+      ) {
+        throw new Error(
+          'transaction data not of correct payload type <SetNamePayload>',
+        );
+      }
+      return {
+        domain: '',
+        showTier: false,
+        compact: false,
+        id: new ArweaveTransactionID(transactionData.assetId),
+        overrides: {
+          nickname: transactionData.name,
+        },
+        disabledKeys: [
+          'evolve',
+          'maxSubdomains',
+          'domain',
+          'leaseDuration',
+          'ttlSeconds',
+        ],
+      };
+    }
+    case INTERACTION_TYPES.SET_TICKER: {
+      if (
+        !isObjectOfTransactionPayloadType<SetTickerPayload>(
+          transactionData,
+          TRANSACTION_DATA_KEYS[INTERACTION_TYPES.SET_TICKER].keys,
+        )
+      ) {
+        throw new Error(
+          `transaction data not of correct payload type <SetTickerPayload> keys: ${Object.keys(
+            transactionData,
+          )}`,
+        );
+      }
+      return {
+        domain: '',
+        showTier: false,
+        compact: false,
+        id: new ArweaveTransactionID(transactionData.assetId),
+        overrides: {
+          ticker: transactionData.ticker,
+        },
+        disabledKeys: [
+          'evolve',
+          'maxSubdomains',
+          'domain',
+          'leaseDuration',
+          'ttlSeconds',
+        ],
+      };
+    }
+    case INTERACTION_TYPES.SET_TARGET_ID: {
+      if (
+        !isObjectOfTransactionPayloadType<SetRecordPayload>(
+          transactionData,
+          TRANSACTION_DATA_KEYS[INTERACTION_TYPES.SET_TARGET_ID].keys,
+        )
+      ) {
+        throw new Error(
+          `transaction data not of correct payload type <SetRecordPayload> keys: ${Object.keys(
+            transactionData,
+          )}`,
+        );
+      }
+      return {
+        domain: '',
+        showTier: false,
+        compact: false,
+        id: new ArweaveTransactionID(transactionData.assetId),
+        overrides: {
+          targetId: transactionData.transactionId,
+        },
+        disabledKeys: [
+          'evolve',
+          'maxSubdomains',
+          'domain',
+          'leaseDuration',
+          'ttlSeconds',
+          'tier',
+        ],
+      };
+    }
+    case INTERACTION_TYPES.SET_TTL_SECONDS: {
+      if (
+        !isObjectOfTransactionPayloadType<SetRecordPayload>(
+          transactionData,
+          TRANSACTION_DATA_KEYS[INTERACTION_TYPES.SET_TTL_SECONDS].keys,
+        )
+      ) {
+        throw new Error(
+          `transaction data not of correct payload type <SetRecordPayload> keys: ${Object.keys(
+            transactionData,
+          )}`,
+        );
+      }
+      return {
+        domain: '',
+        showTier: false,
+        compact: false,
+        id: new ArweaveTransactionID(transactionData.assetId),
+        overrides: {
+          ttlSeconds: transactionData.ttlSeconds,
+        },
+        disabledKeys: [
+          'evolve',
+          'maxSubdomains',
+          'domain',
+          'leaseDuration',
+          'tier',
+        ],
+      };
     }
   }
 }
 
 export const FieldToInteractionMap: {
-  [x: string]: PDNTInteraction;
+  [x: string]: ValidInteractionType;
 } = {
-  name: PDNT_INTERACTION_TYPES.SET_NAME,
-  ticker: PDNT_INTERACTION_TYPES.SET_TICKER,
-  targetID: PDNT_INTERACTION_TYPES.SET_TARGET_ID,
-  ttlSeconds: PDNT_INTERACTION_TYPES.SET_TTL_SECONDS,
+  name: INTERACTION_TYPES.SET_NAME,
+  ticker: INTERACTION_TYPES.SET_TICKER,
+  targetID: INTERACTION_TYPES.SET_TARGET_ID,
+  ttlSeconds: INTERACTION_TYPES.SET_TTL_SECONDS,
   // TODO: add other interactions
 };
 
@@ -327,74 +379,29 @@ export function getInteractionTypeFromField(field: string) {
 }
 
 export function mapTransactionDataKeyToPayload(
-  contractType: ContractType,
-  interactionType: PDNTInteraction | RegistryInteraction,
+  interactionType: ValidInteractionType,
   data: string | number | Array<string | number>,
 ): TransactionData | undefined {
   const txData = typeof data === 'object' ? [...data] : [data];
-  const payload: any = {};
-  // TODO refactor this util and types to be more generic... currently we are implementing dependent on each type, change to not have to do that. Check Mati's types.
   if (!data) {
     throw new Error('No data provided, data is required to build the payload');
   }
-  if (isRegistryInteraction(interactionType)) {
-    if (
-      !isInteractionCompatible({
-        contractType,
-        interactionType,
-        functionName:
-          TRANSACTION_DATA_KEYS[CONTRACT_TYPES.REGISTRY][interactionType]
-            .functionName,
-      })
-    ) {
-      throw new Error(`Interaction is not compatible`);
-    }
-    payload.functionName =
-      TRANSACTION_DATA_KEYS[CONTRACT_TYPES.REGISTRY][
-        interactionType
-      ].functionName;
-    TRANSACTION_DATA_KEYS[CONTRACT_TYPES.REGISTRY][
-      interactionType
-    ].keys.forEach((key, index) => {
+
+  const payload = TRANSACTION_DATA_KEYS[interactionType].keys.reduce(
+    (accum: any, k: string, index: number) => {
       if (!txData[index]) {
         // if missing transaction data from the url, throw an error
         throw new Error(
-          `Missing key (${key}) from transaction data in the url. This may be due to the order of the data, the current order is [${txData}], the correct order is [${
-            TRANSACTION_DATA_KEYS[CONTRACT_TYPES.REGISTRY][interactionType].keys
-          }]`,
+          `Missing key (${k}) from transaction data in the url. This may be due to the order of the data, the current order is [${txData}], the correct order is [${TRANSACTION_DATA_KEYS[interactionType].keys}]`,
         );
       }
-      payload[key] = txData[index];
-    });
-    return payload;
-  }
-  if (isPDNTInteraction(interactionType)) {
-    if (
-      !isInteractionCompatible({
-        contractType,
-        interactionType,
-        functionName:
-          TRANSACTION_DATA_KEYS[CONTRACT_TYPES.PDNT][interactionType]
-            .functionName,
-      })
-    ) {
-      throw new Error(`Interaction is not compatible`);
-    }
-    payload.functionName =
-      TRANSACTION_DATA_KEYS[CONTRACT_TYPES.PDNT][interactionType].functionName;
-    TRANSACTION_DATA_KEYS[CONTRACT_TYPES.PDNT][interactionType].keys.forEach(
-      (key, index) => {
-        if (!txData[index]) {
-          // if missing transaction data from the url, throw an error
-          throw new Error(
-            `Missing key (${key}) from transaction data in the url. This may be due to the order of the data, the current order is [${txData}], the correct order is [${
-              TRANSACTION_DATA_KEYS[CONTRACT_TYPES.PDNT][interactionType].keys
-            }]`,
-          );
-        }
-        payload[key] = txData[index];
-      },
-    );
-    return payload;
-  }
+      accum[k] = txData[index];
+      return accum;
+    },
+    {},
+  );
+  return {
+    ...payload,
+    functionName: TRANSACTION_DATA_KEYS[interactionType].functionName,
+  };
 }

--- a/src/utils/transactionUtils/transactionUtils.ts
+++ b/src/utils/transactionUtils/transactionUtils.ts
@@ -274,6 +274,38 @@ export function getPDNSMappingByInteractionType(
             ],
           };
         }
+        case PDNT_INTERACTION_TYPES.SET_TTL_SECONDS: {
+          if (
+            !isObjectOfTransactionPayloadType<SetRecordPayload>(
+              transactionData,
+              TRANSACTION_DATA_KEYS[CONTRACT_TYPES.PDNT][
+                PDNT_INTERACTION_TYPES.SET_TTL_SECONDS
+              ].keys,
+            )
+          ) {
+            throw new Error(
+              `transaction data not of correct payload type <SetRecordPayload> keys: ${Object.keys(
+                transactionData,
+              )}`,
+            );
+          }
+          return {
+            domain: '',
+            showTier: false,
+            compact: false,
+            id: new ArweaveTransactionID(transactionData.assetId),
+            overrides: {
+              ttlSeconds: transactionData.ttlSeconds,
+            },
+            disabledKeys: [
+              'evolve',
+              'maxSubdomains',
+              'domain',
+              'leaseDuration',
+              'tier',
+            ],
+          };
+        }
       }
     }
   }
@@ -285,6 +317,7 @@ export const FieldToInteractionMap: {
   name: PDNT_INTERACTION_TYPES.SET_NAME,
   ticker: PDNT_INTERACTION_TYPES.SET_TICKER,
   targetID: PDNT_INTERACTION_TYPES.SET_TARGET_ID,
+  ttlSeconds: PDNT_INTERACTION_TYPES.SET_TTL_SECONDS,
   // TODO: add other interactions
 };
 


### PR DESCRIPTION
This PR introduces a more consistent and scalable manner to manage our interaction types. It also consolidates some objects used to structure transactions into unified objects, where an interaction type is the only required input needed to construct the TransactionWorkflow. Doing it this way makes it easier to extend and maintain while avoiding type issues throughout.

Includes recommendations from https://github.com/ar-io/pdns-react/pull/158