### PR TITLE
feat(PE-3627): link undernames buttons in table to page

### DIFF
--- a/src/components/inputs/buttons/ManageAssetButtons/ManageAssetButtons.tsx
+++ b/src/components/inputs/buttons/ManageAssetButtons/ManageAssetButtons.tsx
@@ -1,30 +1,36 @@
+import { useNavigate } from 'react-router-dom';
+
 import { useIsMobile } from '../../../../hooks';
 import { ArweaveTransactionID } from '../../../../types';
-import { ASSET_TYPES } from '../../../../types';
+import { ManageTable } from '../../../../types';
 
 function ManageAssetButtons({
-  // eslint-disable-next-line
-  asset,
-  // eslint-disable-next-line
+  id,
   assetType,
-  setShowModal,
   disabled = true,
 }: {
-  asset: ArweaveTransactionID | string;
-  assetType: ASSET_TYPES;
-  setShowModal: (show: boolean) => void;
+  id: ArweaveTransactionID | string;
+  assetType: ManageTable;
   disabled: boolean;
 }) {
   const isMobile = useIsMobile();
+  const navigate = useNavigate();
 
   return (
     <>
       <div className="flex-row center" style={{ gap: '0.5em' }}>
-        <button className="assets-see-more-button">Undernames</button>
+        <button
+          className="assets-see-more-button"
+          onClick={() =>
+            navigate(`/manage/${assetType}/${id.toString()}/undernames`)
+          }
+        >
+          Undernames
+        </button>
         {!isMobile ? (
           <button
             className="assets-manage-button"
-            onClick={() => setShowModal(true)}
+            onClick={() => navigate(`/manage/${assetType}/${id.toString()}`)}
             disabled={disabled}
           >
             Manage

--- a/src/components/layout/Undernames/Undernames.tsx
+++ b/src/components/layout/Undernames/Undernames.tsx
@@ -121,14 +121,15 @@ function Undernames() {
                       navigate(`/manage/pdnts/${pdntId?.toString()}`)
                     }
                   >
-                    {pdntState?.name.length ? pdntState.name : '[PDNT]'}
+                    {pdntState?.name.length
+                      ? pdntState.name
+                      : `${id?.slice(0, 4)}...${id?.slice(-4)}`}
                   </button>
                 </Tooltip>
                 &nbsp;/&nbsp;
                 <span className="text-large white">Manage Undernames</span>
               </span>
             </div>
-            {/* TODO add table breadcrumb */}
             <div className="flex flex-row flex-right">
               {filteredTableData.length ? (
                 <button
@@ -185,6 +186,7 @@ function Undernames() {
                     total={tableData.length}
                     rootClassName="center"
                     defaultCurrent={1}
+                    showSizeChanger={false}
                   />
                 </>
               ) : (

--- a/src/components/pages/Manage/Manage.tsx
+++ b/src/components/pages/Manage/Manage.tsx
@@ -11,11 +11,7 @@ import {
   useWalletPDNTs,
 } from '../../../hooks';
 import { useGlobalState } from '../../../state/contexts/GlobalState';
-import {
-  ArweaveTransactionID,
-  ManageTable,
-  PDNTMetadata,
-} from '../../../types';
+import { ArweaveTransactionID, ManageTable } from '../../../types';
 import { MANAGE_TABLE_NAMES } from '../../../types';
 import eventEmitter from '../../../utils/events';
 import { CodeSandboxIcon, NotebookIcon, RefreshIcon } from '../../icons';
@@ -32,14 +28,12 @@ function Manage() {
 
   const modalRef = useRef(null);
   const [pdntIds, setPDNTIDs] = useState<ArweaveTransactionID[]>([]);
-  const [selectedRow, setSelectedRow] = useState<PDNTMetadata>();
   const [percent, setPercentLoaded] = useState<number | undefined>();
   const {
     isLoading: pdntTableLoading,
     percent: percentPDNTsLoaded,
     columns: pdntColumns,
     rows: pdntRows,
-    selectedRow: selectedPDNTRow,
     sortAscending: pdntSortAscending,
     sortField: pdntSortField,
   } = useWalletPDNTs(pdntIds);
@@ -83,7 +77,6 @@ function Manage() {
       setTableData(pdntRows);
       setTableColumns(pdntColumns);
       setPercentLoaded(percentPDNTsLoaded);
-      setSelectedRow(selectedPDNTRow);
       const baseIndex = Math.max((tablePage - 1) * 10, 0);
       const endIndex = tablePage * 10;
       const filteredData = pdntRows.slice(baseIndex, endIndex);
@@ -94,7 +87,6 @@ function Manage() {
     pdntSortAscending,
     pdntSortField,
     pdntRows,
-    selectedPDNTRow,
     pdntTableLoading,
     percentPDNTsLoaded,
   ]);
@@ -124,12 +116,6 @@ function Manage() {
   }, [domainTableLoading, pdntTableLoading]);
 
   useEffect(() => {
-    if (selectedRow) {
-      navigate(selectedRow.id);
-    }
-  }, [selectedRow]);
-
-  useEffect(() => {
     if (percent === 100) {
       setPercentLoaded(undefined);
     }
@@ -152,20 +138,12 @@ function Manage() {
     }
   }
 
-  function handleClickOutside(e: any) {
-    if (modalRef.current && modalRef.current === e.target) {
-      setSelectedRow(undefined);
-    }
-    return;
-  }
-
   function updatePage(page: number) {
     setTablePage(page);
   }
 
   return (
-    // eslint-disable-next-line
-    <div className="page" ref={modalRef} onClick={handleClickOutside}>
+    <div className="page" ref={modalRef}>
       <div className="flex-column">
         <div className="flex flex-justify-between">
           <div className="table-selector-group">

--- a/src/hooks/useWalletPDNTs/useWalletPDNTs.tsx
+++ b/src/hooks/useWalletPDNTs/useWalletPDNTs.tsx
@@ -12,7 +12,6 @@ import {
 import ManageAssetButtons from '../../components/inputs/buttons/ManageAssetButtons/ManageAssetButtons';
 import TransactionStatus from '../../components/layout/TransactionStatus/TransactionStatus';
 import {
-  ASSET_TYPES,
   ArweaveTransactionID,
   PDNTContractJSON,
   PDNTMetadata,
@@ -25,7 +24,6 @@ export function useWalletPDNTs(ids: ArweaveTransactionID[]) {
   const { walletAddress } = useWalletAddress();
   const [sortAscending, setSortOrder] = useState(true);
   const [sortField, setSortField] = useState<keyof PDNTMetadata>('status');
-  const [selectedRow, setSelectedRow] = useState<PDNTMetadata>();
   const [rows, setRows] = useState<PDNTMetadata[]>([]);
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [percent, setPercentLoaded] = useState<number | undefined>();
@@ -269,9 +267,8 @@ export function useWalletPDNTs(ids: ArweaveTransactionID[]) {
         title: '',
         render: (val: any, row: PDNTMetadata) => (
           <ManageAssetButtons
-            asset={val.id}
-            setShowModal={() => setSelectedRow(row)}
-            assetType={ASSET_TYPES.PDNT}
+            id={val.id}
+            assetType="pdnts"
             disabled={!row.state || !row.status}
           />
         ),
@@ -327,6 +324,5 @@ export function useWalletPDNTs(ids: ArweaveTransactionID[]) {
     rows,
     sortField,
     sortAscending,
-    selectedRow,
   };
 }


### PR DESCRIPTION
Removes some unnecessary `selectedRow` state attributes and does the routing directly in the `ManageAssetButtons` component