### PR TITLE
fix(PE-3444): use updated warp-contracts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "react-dom": "^18.2.0",
         "react-icons": "^4.6.0",
         "react-router-dom": "^6.4.2",
-        "warp-contracts": "^1.4.5"
+        "warp-contracts": "^1.4.6"
       },
       "devDependencies": {
         "@babel/core": "^7.19.6",
@@ -14484,9 +14484,9 @@
       }
     },
     "node_modules/warp-contracts": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/warp-contracts/-/warp-contracts-1.4.5.tgz",
-      "integrity": "sha512-hUlJt1DXQapPf7cQRUehv9bEMNl6gX9srJ3K3LFAjKvtv2evD22tdcAH0MYHb+QchGIBLqJwva9d2pC7pSA+PQ==",
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/warp-contracts/-/warp-contracts-1.4.6.tgz",
+      "integrity": "sha512-1avBql00HVy9Hc9J5E8pxDo/yfp8HB57J6axWtv2J+O+X/DAlnRK/Lke+pmS/eR3gF/6M/mNb0Tb8Ve7BGTgGA==",
       "dependencies": {
         "archiver": "^5.3.0",
         "arweave": "1.13.7",
@@ -24145,9 +24145,9 @@
       }
     },
     "warp-contracts": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/warp-contracts/-/warp-contracts-1.4.5.tgz",
-      "integrity": "sha512-hUlJt1DXQapPf7cQRUehv9bEMNl6gX9srJ3K3LFAjKvtv2evD22tdcAH0MYHb+QchGIBLqJwva9d2pC7pSA+PQ==",
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/warp-contracts/-/warp-contracts-1.4.6.tgz",
+      "integrity": "sha512-1avBql00HVy9Hc9J5E8pxDo/yfp8HB57J6axWtv2J+O+X/DAlnRK/Lke+pmS/eR3gF/6M/mNb0Tb8Ve7BGTgGA==",
       "requires": {
         "archiver": "^5.3.0",
         "arweave": "1.13.7",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "react-dom": "^18.2.0",
     "react-icons": "^4.6.0",
     "react-router-dom": "^6.4.2",
-    "warp-contracts": "^1.4.5"
+    "warp-contracts": "^1.4.6"
   },
   "devDependencies": {
     "@babel/core": "^7.19.6",


### PR DESCRIPTION
The warp-contracts SDK was previously not loading all of the GQL interactions for a contract when using the arweave custom gateway config. This version bump resolves the issues, making the warp fallback more reliable and consistent with the pdns-service.