### PR TITLE
Bug Fix (PE-3522): size props had invalid size format for firefox

### DIFF
--- a/src/components/modals/CreatePDNTModal/CreatePDNTModal.tsx
+++ b/src/components/modals/CreatePDNTModal/CreatePDNTModal.tsx
@@ -410,8 +410,8 @@ function CreatePDNTModal() {
                                       >
                                         <PencilIcon
                                           style={{
-                                            width: '24',
-                                            height: '24',
+                                            width: '24px',
+                                            height: '24px',
                                             fill: 'white',
                                           }}
                                         />

--- a/src/index.css
+++ b/src/index.css
@@ -55,6 +55,15 @@ input[type='text']:disabled {
   width: '100%';
   overflow: ellipse;
 }
+input[type=number]:disabled:-webkit-outer-spin-button,
+input[type=number]:disabled:-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+}
+
+input[type=number]:disabled {
+    -moz-appearance:textfield;
+}
 
 .bold {
   font-family: 'Rubik-Bold';
@@ -569,3 +578,4 @@ input[type='text']:disabled {
 .ant-pagination-item-active > a {
   background-color: var(--text-faded) !important;
 }
+


### PR DESCRIPTION
![image](https://github.com/ar-io/pdns-react/assets/85306700/0ae71589-e323-44d1-8a1e-57d362f4d63a)
