### PR TITLE
fix(PE-3789): use contact class in hooks to prevent errors, cleanup som…

### DIFF
--- a/src/components/inputs/buttons/ManageAssetButtons/ManageAssetButtons.tsx
+++ b/src/components/inputs/buttons/ManageAssetButtons/ManageAssetButtons.tsx
@@ -20,7 +20,12 @@ function ManageAssetButtons({
     <>
       <div className="flex-row center" style={{ gap: '0.5em' }}>
         <button
-          className="assets-see-more-button"
+          className={
+            disabled
+              ? 'assets-see-more-button disabled-button'
+              : 'assets-see-more-button'
+          }
+          disabled={disabled}
           onClick={() =>
             navigate(`/manage/${assetType}/${id.toString()}/undernames`)
           }
@@ -29,7 +34,11 @@ function ManageAssetButtons({
         </button>
         {!isMobile ? (
           <button
-            className="assets-manage-button"
+            className={
+              disabled
+                ? 'assets-manage-button disabled-button'
+                : 'assets-manage-button'
+            }
             onClick={() => navigate(`/manage/${assetType}/${id.toString()}`)}
             disabled={disabled}
           >

--- a/src/components/layout/RegisterNameForm/RegisterNameForm.tsx
+++ b/src/components/layout/RegisterNameForm/RegisterNameForm.tsx
@@ -100,7 +100,9 @@ function RegisterNameForm() {
 
       dispatchRegisterState({
         type: 'setTargetID',
-        payload: new ArweaveTransactionID(pdnt.getRecord('@').transactionId),
+        payload: new ArweaveTransactionID(
+          pdnt.getRecord('@')?.transactionId ?? '',
+        ),
       });
 
       setIsValidPDNT(true);

--- a/src/components/layout/Undernames/Undernames.tsx
+++ b/src/components/layout/Undernames/Undernames.tsx
@@ -231,9 +231,7 @@ function Undernames() {
             ) {
               throw new Error('Mismatching payload and interation type!');
             }
-            if (!changesValid) {
-              throw new Error('Changes not valid, fix errors to continue');
-            }
+            // don't check validity - there are no inputs
             dispatchTransactionState({
               type: 'setInteractionType',
               payload: INTERACTION_TYPES.REMOVE_RECORD,

--- a/src/components/modals/CreatePDNTModal/CreatePDNTModal.tsx
+++ b/src/components/modals/CreatePDNTModal/CreatePDNTModal.tsx
@@ -16,7 +16,12 @@ import {
   VALIDATION_INPUT_TYPES,
 } from '../../../types';
 import { mapTransactionDataKeyToPayload } from '../../../utils';
-import { DEFAULT_PDNT_SOURCE_CODE_TX } from '../../../utils/constants';
+import {
+  DEFAULT_MAX_UNDERNAMES,
+  DEFAULT_PDNT_SOURCE_CODE_TX,
+  DEFAULT_TTL_SECONDS,
+  STUB_ARWEAVE_TXID,
+} from '../../../utils/constants';
 import eventEmitter from '../../../utils/events';
 import { mapKeyToAttribute } from '../../cards/PDNTCard/PDNTCard';
 import { CloseIcon, PencilIcon } from '../../icons';
@@ -93,8 +98,8 @@ function CreatePDNTModal() {
     const consolidatedDetails: any = {
       name: pdnt.name,
       ticker: pdnt.ticker,
-      targetID: pdnt.getRecord('@').transactionId,
-      ttlSeconds: pdnt.getRecord('@').ttlSeconds,
+      targetID: pdnt.getRecord('@')?.transactionId ?? '',
+      ttlSeconds: pdnt.getRecord('@')?.ttlSeconds ?? DEFAULT_TTL_SECONDS,
       controller: pdnt.controller,
       owner: pdnt.owner,
     };
@@ -139,7 +144,10 @@ function CreatePDNTModal() {
         case 'targetID':
           pdnt.records = {
             '@': {
-              ...pdnt.getRecord('@'),
+              maxUndernames:
+                pdnt.getRecord('@')?.maxUndernames ?? DEFAULT_MAX_UNDERNAMES,
+              ttlSeconds:
+                pdnt.getRecord('@')?.ttlSeconds ?? DEFAULT_TTL_SECONDS,
               transactionId: modifiedValue.toString(),
             },
           };
@@ -147,7 +155,10 @@ function CreatePDNTModal() {
         case 'ttlSeconds':
           pdnt.records = {
             '@': {
-              ...pdnt.getRecord('@'),
+              maxUndernames:
+                pdnt.getRecord('@')?.maxUndernames ?? DEFAULT_MAX_UNDERNAMES,
+              transactionId:
+                pdnt.getRecord('@')?.transactionId ?? STUB_ARWEAVE_TXID,
               ttlSeconds: +modifiedValue,
             },
           };

--- a/src/services/arweave/ArweaveCompositeDataProvider.ts
+++ b/src/services/arweave/ArweaveCompositeDataProvider.ts
@@ -37,10 +37,10 @@ export class ArweaveCompositeDataProvider
   }
 
   async getContractState<T extends PDNSContractJSON | PDNTContractJSON>(
-    id: ArweaveTransactionID,
+    contractTxId: ArweaveTransactionID,
   ): Promise<T> {
     return Promise.any(
-      this._contractProviders.map((p) => p.getContractState<T>(id)),
+      this._contractProviders.map((p) => p.getContractState<T>(contractTxId)),
     );
   }
 
@@ -146,10 +146,12 @@ export class ArweaveCompositeDataProvider
   }
 
   async getContractInteractions(
-    id: ArweaveTransactionID,
+    contractTxId: ArweaveTransactionID,
   ): Promise<ContractInteraction[]> {
     return Promise.any(
-      this._contractProviders.map((p) => p.getContractInteractions(id)),
+      this._contractProviders.map((p) =>
+        p.getContractInteractions(contractTxId),
+      ),
     );
   }
 }

--- a/src/services/arweave/PDNSContractCache.ts
+++ b/src/services/arweave/PDNSContractCache.ts
@@ -14,19 +14,21 @@ export class PDNSContractCache implements SmartweaveContractCache {
   }
 
   async getContractState<T extends PDNTContractJSON | PDNSContractJSON>(
-    id: ArweaveTransactionID,
+    contractTxId: ArweaveTransactionID,
   ): Promise<T> {
-    const res = await fetch(`${this._url}/contract/${id.toString()}`);
+    const res = await fetch(`${this._url}/contract/${contractTxId.toString()}`);
     const { state } = await res.json();
     return state as T;
   }
 
   async getContractBalanceForWallet(
-    id: ArweaveTransactionID,
+    contractTxId: ArweaveTransactionID,
     wallet: ArweaveTransactionID,
   ): Promise<number> {
     const res = await fetch(
-      `${this._url}/contract/${id.toString()}/balances/${wallet.toString()}`,
+      `${
+        this._url
+      }/contract/${contractTxId.toString()}/balances/${wallet.toString()}`,
     );
     const { balance } = await res.json();
     return +balance ?? 0;

--- a/src/services/arweave/PDNTContract.ts
+++ b/src/services/arweave/PDNTContract.ts
@@ -73,23 +73,24 @@ export class PDNTContract {
     ] of Object.entries(records)) {
       this.contract.records[domain] = {
         transactionId: transactionId
-          ? transactionId.toString()
-          : this.getRecord(domain).transactionId.toString(),
+          ? transactionId
+          : this.getRecord(domain)?.transactionId ?? '',
         maxUndernames: maxUndernames
           ? maxUndernames
-          : this.getRecord(domain).maxUndernames,
+          : this.getRecord(domain)?.maxUndernames ?? DEFAULT_MAX_UNDERNAMES,
         ttlSeconds: ttlSeconds
           ? ttlSeconds
-          : this.getRecord(domain).maxUndernames,
+          : this.getRecord(domain)?.ttlSeconds ?? DEFAULT_TTL_SECONDS,
       };
     }
   }
 
-  getRecord(name: string): PDNTContractDomainRecord {
+  getRecord(name: string): PDNTContractDomainRecord | undefined {
+    if (!this.contract.records[name]) return undefined;
     if (typeof this.contract.records[name] == 'string') {
       return {
         ttlSeconds: DEFAULT_TTL_SECONDS,
-        transactionId: (this.contract.records[name] as string) ?? '',
+        transactionId: this.contract.records[name] as string,
         maxUndernames: DEFAULT_MAX_UNDERNAMES,
       };
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -100,10 +100,10 @@ export type JsonWalletProvider = {
 
 export interface SmartweaveContractCache {
   getContractState<T extends PDNTContractJSON | PDNSContractJSON>(
-    id: ArweaveTransactionID,
+    contractTxId: ArweaveTransactionID,
   ): Promise<T>;
   getContractBalanceForWallet(
-    id: ArweaveTransactionID,
+    contractTxId: ArweaveTransactionID,
     wallet: ArweaveTransactionID,
   ): Promise<number>;
   getContractsForWallet(
@@ -111,7 +111,7 @@ export interface SmartweaveContractCache {
     address: ArweaveTransactionID,
   ): Promise<{ ids: ArweaveTransactionID[] }>;
   getContractInteractions(
-    id: ArweaveTransactionID,
+    contractTxId: ArweaveTransactionID,
   ): Promise<ContractInteraction[]>;
 }
 


### PR DESCRIPTION
…e table functionality, and set parameters to consistent values for cache provider

An error will now be thrown if unable to load the contract state. Manage buttons will be disabled (although the row should not load).